### PR TITLE
Fixed bugs and updated code that has been depreciated in libraries

### DIFF
--- a/sbkm/sbkm.py
+++ b/sbkm/sbkm.py
@@ -1,6 +1,6 @@
 import numpy as np
 from sklearn.base import BaseEstimator
-# sklearn.linear_model._base is deprecated
+# sklearn.linear_model.base is deprecated
 from sklearn.linear_model._base import LinearClassifierMixin
 from sklearn.utils import check_X_y,check_array
 from sklearn.utils.multiclass import check_classification_targets


### PR DESCRIPTION
This update has been modified for the latest version of the libraries: `numpy 1.24.1, scipy 1.10.1, pandas 2.0.3, rtree 1.3.0, matplotlib 3.1.2, scikit-learn 1.3.2`.

In `sbkm.py`:
- Some depreciated functions have been modified.
- The cost calculation resulted in a vector in the `_gaussian_cost_grad` function. This has been fixed (by adding a dot product), and it returns a scalar now.
-  In the `_posterior_dist_local` function, `fmin_l_bfgs_b` was being called incorrectly (the cost and gradient were not given as separate parameters). This has been fixed
- In `fit`, the None value handling was not working correctly. This has been modified